### PR TITLE
Add initial BitChat protocol for ESP32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ dkms.conf
 # debug information files
 *.dwo
 bitchat
+bitchat-swift/

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-CC=gcc
-CFLAGS=-Ivendor/libsodium/include -Wall -Wextra -O2
-LDFLAGS=vendor/libsodium/lib/libsodium.a
+CC=clang
+CFLAGS=-Ivendor/libsodium/include -Iinclude -Wall -Wextra -O2
+LDFLAGS=-lsodium
 TARGET=bitchat
-SRC=src/main.c
+SRC=src/main.c src/bitchat_protocol.c
 
 all: $(TARGET)
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # bitchat
 
-This repository contains a minimal hello world written in C. It demonstrates a basic setup
-using [libsodium](https://github.com/jedisct1/libsodium) for cryptographic primitives and
-includes a vendored copy of the ESP-IDF template.
+bitchat in C for portability to ESP32 devices. Requires libsodium because implementing crypto is dumb.
+
+A decentralized peer-to-peer messaging app that works over Bluetooth mesh networks. No internet required, no servers, no phone numbers. It's the side-groupchat.
 
 ## Building
 
-The project uses `make` with `gcc`. The only dependency is the vendored
-`libsodium` library located under `vendor/libsodium`.
+The project uses `make` with `clang`. The only dependency is the
+`libsodium` library, available as a system package or prebuilt under
+`vendor/libsodium`.
 
 To build the hello world executable run:
 

--- a/include/bitchat_protocol.h
+++ b/include/bitchat_protocol.h
@@ -1,0 +1,39 @@
+#ifndef BITCHAT_PROTOCOL_H
+#define BITCHAT_PROTOCOL_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define BITCHAT_MAX_PAYLOAD 512
+
+typedef enum {
+    BITCHAT_TYPE_ANNOUNCE       = 0x01,
+    BITCHAT_TYPE_LEAVE          = 0x03,
+    BITCHAT_TYPE_MESSAGE        = 0x04,
+    BITCHAT_TYPE_DELIVERY_ACK   = 0x0A,
+} bitchat_msg_type_t;
+
+struct bitchat_packet {
+    uint8_t  version;
+    uint8_t  type;
+    uint8_t  ttl;
+    uint64_t timestamp;
+    uint8_t  sender_id[8];
+    uint8_t  recipient_id[8];
+    int      has_recipient;
+    size_t   payload_len;
+    uint8_t  payload[BITCHAT_MAX_PAYLOAD];
+};
+
+int bitchat_decode_packet(struct bitchat_packet *pkt, const uint8_t *data, size_t len);
+void bitchat_print_packet(const struct bitchat_packet *pkt);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BITCHAT_PROTOCOL_H

--- a/src/bitchat_protocol.c
+++ b/src/bitchat_protocol.c
@@ -1,0 +1,79 @@
+#include "bitchat_protocol.h"
+#include <stdio.h>
+
+static uint64_t read_u64_be(const uint8_t *buf)
+{
+    uint64_t v = 0;
+    for (int i = 0; i < 8; i++) {
+        v = (v << 8) | buf[i];
+    }
+    return v;
+}
+
+int bitchat_decode_packet(struct bitchat_packet *pkt, const uint8_t *data, size_t len)
+{
+    if (!pkt || !data || len < 13) { // minimal header
+        return -1;
+    }
+
+    size_t offset = 0;
+    pkt->version = data[offset++];
+    pkt->type    = data[offset++];
+    pkt->ttl     = data[offset++];
+
+    pkt->timestamp = read_u64_be(data + offset);
+    offset += 8;
+
+    uint8_t flags = data[offset++];
+    int has_recipient = flags & 0x01;
+    pkt->has_recipient = has_recipient;
+
+    uint16_t payload_len = (data[offset] << 8) | data[offset+1];
+    offset += 2;
+
+    if (len < offset + 8 + (has_recipient ? 8 : 0) + payload_len) {
+        return -1;
+    }
+
+    for (int i = 0; i < 8; i++) {
+        pkt->sender_id[i] = data[offset+i];
+    }
+    offset += 8;
+
+    if (has_recipient) {
+        for (int i = 0; i < 8; i++) {
+            pkt->recipient_id[i] = data[offset+i];
+        }
+        offset += 8;
+    }
+
+    pkt->payload_len = payload_len;
+    if (payload_len > BITCHAT_MAX_PAYLOAD) {
+        payload_len = BITCHAT_MAX_PAYLOAD;
+    }
+    for (size_t i = 0; i < payload_len; i++) {
+        pkt->payload[i] = data[offset+i];
+    }
+    return 0;
+}
+
+void bitchat_print_packet(const struct bitchat_packet *pkt)
+{
+    if (!pkt) return;
+    printf("BitChat packet\n");
+    printf("  version: %u\n", pkt->version);
+    printf("  type: 0x%02X\n", pkt->type);
+    printf("  ttl: %u\n", pkt->ttl);
+    printf("  timestamp: %llu\n", (unsigned long long)pkt->timestamp);
+    printf("  sender: ");
+    for (int i = 0; i < 8; i++) printf("%02X", pkt->sender_id[i]);
+    printf("\n");
+    if (pkt->has_recipient) {
+        printf("  recipient: ");
+        for (int i = 0; i < 8; i++) printf("%02X", pkt->recipient_id[i]);
+        printf("\n");
+    }
+    printf("  payload (%zu bytes): ", pkt->payload_len);
+    for (size_t i = 0; i < pkt->payload_len; i++) printf("%02X", pkt->payload[i]);
+    printf("\n");
+}

--- a/src/esp32_receiver.c
+++ b/src/esp32_receiver.c
@@ -1,0 +1,73 @@
+#include <string.h>
+#include <stdio.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_log.h"
+#include "nvs_flash.h"
+#include "esp_bt.h"
+#include "esp_gap_ble_api.h"
+#include "esp_gatts_api.h"
+#include "esp_bt_main.h"
+#include "bitchat_protocol.h"
+
+static const char *TAG = "bitchat";
+
+static uint16_t bitchat_handle_table[2];
+
+static const uint8_t service_uuid128[16] = {
+    0xF4,0x7B,0x5E,0x2D,0x4A,0x9E,0x4C,0x5A,
+    0x9B,0x3F,0x8E,0x1D,0x2C,0x3A,0x4B,0x5C
+};
+static const uint8_t char_uuid128[16] = {
+    0xA1,0xB2,0xC3,0xD4,0xE5,0xF6,0x4A,0x5B,
+    0x8C,0x9D,0x0E,0x1F,0x2A,0x3B,0x4C,0x5D
+};
+
+static void gatts_write_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if,
+                                      esp_ble_gatts_cb_param_t *param)
+{
+    if (param->write.handle == bitchat_handle_table[1]) {
+        bitchat_packet pkt;
+        bitchat_decode_packet(&pkt, param->write.value, param->write.len);
+        ESP_LOGI(TAG, "Received packet");
+        bitchat_print_packet(&pkt);
+    }
+}
+
+static void gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if,
+                                esp_ble_gatts_cb_param_t *param)
+{
+    switch (event) {
+    case ESP_GATTS_WRITE_EVT:
+        gatts_write_event_handler(event, gatts_if, param);
+        break;
+    default:
+        break;
+    }
+}
+
+void app_main(void)
+{
+    esp_err_t ret = nvs_flash_init();
+    if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+        ESP_ERROR_CHECK(nvs_flash_erase());
+        ret = nvs_flash_init();
+    }
+    ESP_ERROR_CHECK(ret);
+
+    ESP_ERROR_CHECK(esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT));
+
+    esp_bt_controller_config_t bt_cfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
+    ESP_ERROR_CHECK(esp_bt_controller_init(&bt_cfg));
+    ESP_ERROR_CHECK(esp_bt_controller_enable(ESP_BT_MODE_BLE));
+
+    ESP_ERROR_CHECK(esp_bluedroid_init());
+    ESP_ERROR_CHECK(esp_bluedroid_enable());
+
+    esp_ble_gatts_register_callback(gatts_event_handler);
+    esp_ble_gatts_app_register(0);
+
+    while (1) {
+        vTaskDelay(1000 / portTICK_PERIOD_MS);
+    }
+}


### PR DESCRIPTION
## Summary
- update README to describe BitChat and libsodium requirement
- ignore reference Swift repository
- add C protocol implementation and ESP32 BLE receiver skeleton
- use clang and libsodium for build

## Testing
- `make clean && make`

------
https://chatgpt.com/codex/tasks/task_e_68898c19a0448329b03f77059c4b90d2